### PR TITLE
Add flag to not wait until element is visible

### DIFF
--- a/conductor-client/src/main/java/conductor/Conductor.kt
+++ b/conductor-client/src/main/java/conductor/Conductor.kt
@@ -54,7 +54,6 @@ class Conductor(private val driver: Driver) : AutoCloseable {
         waitForAppToSettle()
     }
 
-
     fun swipe(start: Point, end: Point) {
         LOGGER.info("Swiping from (${start.x},${start.y}) to (${end.x},${end.y})")
 
@@ -73,16 +72,26 @@ class Conductor(private val driver: Driver) : AutoCloseable {
         tap(element.toUiElement())
     }
 
-    fun tap(element: UiElement, retryIfNoChange: Boolean = true) {
+    fun tap(
+        element: UiElement,
+        retryIfNoChange: Boolean = true,
+        waitUntilVisible: Boolean = true,
+    ) {
         LOGGER.info("Tapping on element: $element")
 
-        waitUntilVisible(element)
+        if (waitUntilVisible) {
+            waitUntilVisible(element)
+        }
 
         val center = element.bounds.center()
         tap(center.x, center.y, retryIfNoChange)
     }
 
-    fun tap(x: Int, y: Int, retryIfNoChange: Boolean = true) {
+    fun tap(
+        x: Int,
+        y: Int,
+        retryIfNoChange: Boolean = true,
+    ) {
         LOGGER.info("Tapping at ($x, $y)")
 
         val hierarchyBeforeTap = viewHierarchy()
@@ -112,7 +121,7 @@ class Conductor(private val driver: Driver) : AutoCloseable {
         repeat(10) {
             if (!ViewUtils.isVisible(viewHierarchy(), element.treeNode)) {
                 LOGGER.info("Element is not visible yet. Waiting.")
-                Thread.sleep(1000)
+                ConductorTimer.sleep(ConductorTimer.Reason.WAIT_UNTIL_VISIBLE, 1000)
             } else {
                 LOGGER.info("Element became visible.")
                 return
@@ -218,7 +227,7 @@ class Conductor(private val driver: Driver) : AutoCloseable {
 
     private fun waitForAppToSettle() {
         // Time buffer for any visual effects and transitions that might occur between actions.
-        Thread.sleep(1000)
+        ConductorTimer.sleep(ConductorTimer.Reason.BUFFER, 1000)
 
         val hierarchyBefore = viewHierarchy()
         repeat(10) {
@@ -226,7 +235,7 @@ class Conductor(private val driver: Driver) : AutoCloseable {
             if (hierarchyBefore == hierarchyAfter) {
                 return
             }
-            Thread.sleep(200)
+            ConductorTimer.sleep(ConductorTimer.Reason.WAIT_TO_SETTLE, 200)
         }
     }
 

--- a/conductor-client/src/main/java/conductor/ConductorTimer.kt
+++ b/conductor-client/src/main/java/conductor/ConductorTimer.kt
@@ -1,0 +1,18 @@
+package conductor
+
+object ConductorTimer {
+
+    var sleep: (Reason, Long) -> Unit = { _, ms -> Thread.sleep(ms) }
+        private set
+
+    fun setTimerFunc(sleep: (Reason, Long) -> Unit) {
+        this.sleep = sleep
+    }
+
+    enum class Reason {
+        WAIT_UNTIL_VISIBLE,
+        WAIT_TO_SETTLE,
+        BUFFER,
+    }
+
+}

--- a/conductor-orchestra-models/src/main/java/conductor/orchestra/Commands.kt
+++ b/conductor-orchestra-models/src/main/java/conductor/orchestra/Commands.kt
@@ -98,7 +98,8 @@ class BackPressCommand : Command {
 
 data class TapOnElementCommand(
     val selector: ElementSelector,
-    val retryIfNoChange: Boolean? = null
+    val retryIfNoChange: Boolean? = null,
+    val waitUntilVisible: Boolean? = null,
 ) : Command {
 
     override fun description(): String {
@@ -110,7 +111,8 @@ data class TapOnElementCommand(
 data class TapOnPointCommand(
     val x: Int,
     val y: Int,
-    val retryIfNoChange: Boolean? = null
+    val retryIfNoChange: Boolean? = null,
+    val waitUntilVisible: Boolean? = null,
 ) : Command {
 
     override fun description(): String {

--- a/conductor-orchestra/src/main/java/conductor/orchestra/Orchestra.kt
+++ b/conductor-orchestra/src/main/java/conductor/orchestra/Orchestra.kt
@@ -50,10 +50,17 @@ class Orchestra(
     private fun executeCommand(command: ConductorCommand) {
         when {
             command.tapOnElement != null -> command.tapOnElement?.let {
-                tapOnElement(it, it.retryIfNoChange ?: true)
+                tapOnElement(
+                    it,
+                    it.retryIfNoChange ?: true,
+                    it.waitUntilVisible ?: true,
+                )
             }
             command.tapOnPoint != null -> command.tapOnPoint?.let {
-                tapOnPoint(it, it.retryIfNoChange ?: true)
+                tapOnPoint(
+                    it,
+                    it.retryIfNoChange ?: true,
+                )
             }
             command.backPressCommand != null -> conductor.backPress()
             command.scrollCommand != null -> conductor.scrollVertical()
@@ -84,10 +91,18 @@ class Orchestra(
         findElement(selector) // Throws if element is not found
     }
 
-    private fun tapOnElement(command: TapOnElementCommand, retryIfNoChange: Boolean) {
+    private fun tapOnElement(
+        command: TapOnElementCommand,
+        retryIfNoChange: Boolean,
+        waitUntilVisible: Boolean,
+    ) {
         try {
             val element = findElement(command.selector)
-            conductor.tap(element, retryIfNoChange)
+            conductor.tap(
+                element,
+                retryIfNoChange,
+                waitUntilVisible
+            )
         } catch (e: ConductorException.ElementNotFound) {
 
             if (!command.selector.optional) {
@@ -96,7 +111,10 @@ class Orchestra(
         }
     }
 
-    private fun tapOnPoint(command: TapOnPointCommand, retryIfNoChange: Boolean) {
+    private fun tapOnPoint(
+        command: TapOnPointCommand,
+        retryIfNoChange: Boolean,
+    ) {
         conductor.tap(
             command.x,
             command.y,

--- a/conductor-orchestra/src/main/java/conductor/orchestra/yaml/YamlElementSelector.kt
+++ b/conductor-orchestra/src/main/java/conductor/orchestra/yaml/YamlElementSelector.kt
@@ -30,6 +30,7 @@ data class YamlElementSelector(
     val tolerance: Int? = null,
     val optional: Boolean? = null,
     val retryTapIfNoChange: Boolean? = null,
+    val waitUntilVisible: Boolean? = null,
     val point: String? = null,
     val start: String? = null,
     val end: String? = null,

--- a/conductor-orchestra/src/main/java/conductor/orchestra/yaml/YamlFluentCommand.kt
+++ b/conductor-orchestra/src/main/java/conductor/orchestra/yaml/YamlFluentCommand.kt
@@ -67,6 +67,7 @@ data class YamlFluentCommand(
 
     private fun tapCommand(tapOn: YamlElementSelectorUnion): ConductorCommand {
         val retryIfNoChange = (tapOn as? YamlElementSelector)?.retryTapIfNoChange ?: true
+        val waitUntilVisible = (tapOn as? YamlElementSelector)?.waitUntilVisible ?: true
         val point = (tapOn as? YamlElementSelector)?.point
 
         return if (point != null) {
@@ -79,14 +80,16 @@ data class YamlFluentCommand(
                 tapOnPoint = TapOnPointCommand(
                     x = points[0],
                     y = points[1],
-                    retryIfNoChange = retryIfNoChange
+                    retryIfNoChange = retryIfNoChange,
+                    waitUntilVisible = waitUntilVisible,
                 )
             )
         } else {
             ConductorCommand(
                 tapOnElement = TapOnElementCommand(
-                    toElementSelector(tapOn),
-                    retryIfNoChange
+                    selector = toElementSelector(tapOn),
+                    retryIfNoChange = retryIfNoChange,
+                    waitUntilVisible = waitUntilVisible,
                 )
             )
         }

--- a/conductor-test/src/main/kotlin/conductor/test/drivers/FakeTimer.kt
+++ b/conductor-test/src/main/kotlin/conductor/test/drivers/FakeTimer.kt
@@ -1,0 +1,26 @@
+package conductor.test.drivers
+
+import conductor.ConductorTimer
+
+class FakeTimer {
+
+    private val events = mutableListOf<Event>()
+
+    fun timer(): (ConductorTimer.Reason, Long) -> Unit {
+        return { reason, time ->
+            events.add(Event(reason, time))
+        }
+    }
+
+    fun assertNoEvent(reason: ConductorTimer.Reason) {
+        if (events.any { it.reason == reason }) {
+            throw AssertionError("Timer event for $reason was not expected")
+        }
+    }
+
+    private data class Event(
+        val reason: ConductorTimer.Reason,
+        val time: Long,
+    )
+
+}

--- a/conductor-test/src/test/resources/019_dont_wait_for_visibility.yaml
+++ b/conductor-test/src/test/resources/019_dont_wait_for_visibility.yaml
@@ -1,0 +1,4 @@
+- tapOn:
+    text: "Button"
+    retryTapIfNoChange: false
+    waitUntilVisible: false


### PR DESCRIPTION
Needed in cases where app has a full-screen overlay. Waiting for element to become visible just introduces an unnecessary delay